### PR TITLE
Update nginx body size

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookstack
 description: Wiki application made by Bookstack and MySQL
 type: application
-version: 1.12.0
+version: 1.12.1o
 appVersion: "24.12"
 sources:
   - https://github.com/pacroy/bookstack-helm

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bookstack
 description: Wiki application made by Bookstack and MySQL
 type: application
-version: 1.12.1o
+version: 1.12.1
 appVersion: "24.12"
 sources:
   - https://github.com/pacroy/bookstack-helm

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.allow-http: {{ .Values.allowHttp | default "false" | quote }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.org/client-max-body-size: "10m"
     acme.cert-manager.io/http01-edit-in-place: "true"
   name: {{ printf "%s-%s" .Release.Name "bookstack" }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This pull request includes a version bump for the Helm chart and updates the Ingress configuration to use a different annotation for controlling the maximum client body size.

Helm chart version update:

* Bumped the chart version in `Chart.yaml` from `1.12.0` to `1.12.1` to reflect the changes.

Ingress configuration changes:

* Replaced the deprecated `nginx.ingress.kubernetes.io/proxy-body-size` annotation with `nginx.org/client-max-body-size` in `templates/ingress.yaml` for better compatibility with NGINX Ingress Controller.